### PR TITLE
WIP: Better onboarding

### DIFF
--- a/app/src/main/java/com/jmstudios/redmoon/AboutFragment.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/AboutFragment.kt
@@ -20,7 +20,7 @@ class AboutFragment : PreferenceFragment() {
         Log.i("onCreate()")
         super.onCreate(savedInstanceState)
         addPreferencesFromResource(R.xml.about)
-        pref(R.string.pref_key_version).apply{
+        pref<Preference>(R.string.pref_key_version).apply{
             summary = BuildConfig.VERSION_NAME
             onPreferenceClickListener = Preference.OnPreferenceClickListener {
                 ChangeLog(activity).fullLogDialog.show()

--- a/app/src/main/java/com/jmstudios/redmoon/BaseFragment.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/BaseFragment.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2017 Stephen Michel <s@smichel.me>
+ * SPDX-License-Identifier: GPL-3.0+
+ */
+package com.jmstudios.redmoon
+
+import android.os.Bundle
+import android.preference.Preference
+import android.preference.PreferenceFragment
+import android.preference.TwoStatePreference
+import android.support.design.widget.BaseTransientBottomBar.BaseCallback
+import android.support.design.widget.Snackbar
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+
+import com.jmstudios.redmoon.R
+
+import com.jmstudios.redmoon.model.Profile
+import com.jmstudios.redmoon.model.Config
+import com.jmstudios.redmoon.ui.preference.SeekBarPreference
+import com.jmstudios.redmoon.ui.preference.ProfileSelectorPreference
+import com.jmstudios.redmoon.util.*
+
+abstract class BaseFragment : PreferenceFragment() {
+
+    private lateinit var mSnackbar: Snackbar
+    private lateinit var padding: Preference
+
+    private val needsPermissions: Boolean
+        get() = !Permission.Overlay.isGranted
+             || (Config.scheduleOn && Config.useLocation && !Permission.Location.isGranted)
+             || (Config.secureSuspend && !Permission.UsageStats.isGranted)
+             || (Config.lowerBrightness && !Permission.WriteSettings.isGranted)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        Log.i("onCreate()")
+        super.onCreate(savedInstanceState)
+
+        padding = Preference(activity).apply {
+            layoutResource = R.layout.preference_padding
+            isSelectable = false
+            order = 100 // always at bottom
+        }
+    }
+
+    override fun onStart() {
+        Log.i("onStart")
+        super.onStart()
+
+        mSnackbar = Snackbar.make(view, R.string.permission_snackbar_text, Snackbar.LENGTH_INDEFINITE).apply {
+            setAction(R.string.permission_snackbar_action) {
+                Log.i("snackbar tapped")
+            }
+            addCallback(object: BaseCallback<Snackbar>() {
+                override fun onShown(s: Snackbar) {
+                    Log.i("onShown()")
+                    preferenceScreen.addPreference(padding)
+                }
+                override fun onDismissed(s: Snackbar, event: Int) {
+                    Log.i("onDismissed()")
+                    preferenceScreen.removePreference(padding)
+                }
+            })
+        }
+
+        if (Config.darkThemeFlag) {
+            val group = mSnackbar.view as ViewGroup
+            group.setBackgroundColor(getColor(R.color.snackbar_color_dark_theme))
+
+            val snackbarTextId = android.support.design.R.id.snackbar_text
+            val textView = group.findViewById<TextView>(snackbarTextId)
+            textView.setTextColor(getColor(R.color.text_color_dark_theme))
+        }
+
+        if (needsPermissions) {
+            mSnackbar.show()
+        } else {
+            mSnackbar.dismiss()
+        }
+    }
+
+    companion object: Logger()
+}
+

--- a/app/src/main/java/com/jmstudios/redmoon/FilterFragment.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/FilterFragment.kt
@@ -28,6 +28,11 @@ import android.os.Bundle
 import android.preference.Preference
 import android.preference.PreferenceFragment
 import android.preference.TwoStatePreference
+import android.support.design.widget.BaseTransientBottomBar.BaseCallback
+import android.support.design.widget.Snackbar
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
 
 import com.jmstudios.redmoon.R
 
@@ -39,7 +44,7 @@ import com.jmstudios.redmoon.util.*
 
 import org.greenrobot.eventbus.Subscribe
 
-class FilterFragment : PreferenceFragment() {
+class FilterFragment : BaseFragment() {
 
     private val profileSelectorPref: ProfileSelectorPreference
         get() = pref(R.string.pref_key_profile_spinner)
@@ -66,6 +71,7 @@ class FilterFragment : PreferenceFragment() {
         get() = pref(R.string.pref_key_button_backlight)
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        Log.i("onCreate()")
         super.onCreate(savedInstanceState)
         addPreferencesFromResource(R.xml.filter_preferences)
 

--- a/app/src/main/java/com/jmstudios/redmoon/MainActivity.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/MainActivity.kt
@@ -79,8 +79,8 @@ class MainActivity : ThemedAppCompatActivity() {
     fun SwitchCompat.safeSetChecked(checked: Boolean) {
         setOnCheckedChangeListener { _, _ ->  }
         isChecked = checked
-        setOnCheckedChangeListener { _, checked ->
-            Command.toggle(checked)
+        setOnCheckedChangeListener { _, newChecked ->
+            Command.toggle(newChecked)
         }
     }
 
@@ -141,10 +141,5 @@ class MainActivity : ThemedAppCompatActivity() {
     @Subscribe fun onFilterIsOnChanged(event: filterIsOnChanged) {
         Log.i("FilterIsOnChanged")
         mSwitch?.safeSetChecked(filterIsOn)
-    }
-
-    @Subscribe fun onOverlayPermissionDenied(event: overlayPermissionDenied) {
-        mSwitch?.safeSetChecked(false)
-        Permission.Overlay.request(this)
     }
 }

--- a/app/src/main/java/com/jmstudios/redmoon/ScheduleFragment.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/ScheduleFragment.kt
@@ -21,7 +21,7 @@ import com.jmstudios.redmoon.util.*
 
 import org.greenrobot.eventbus.Subscribe
 
-class ScheduleFragment : PreferenceFragment() {
+class ScheduleFragment : BaseFragment() {
 
     // Preferences
     private val switchBar: SwitchPreference

--- a/app/src/main/java/com/jmstudios/redmoon/SecureSuspendFragment.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/SecureSuspendFragment.kt
@@ -17,7 +17,7 @@ import com.jmstudios.redmoon.securesuspend.CurrentAppChecker
 import com.jmstudios.redmoon.R
 import com.jmstudios.redmoon.util.*
 
-class SecureSuspendFragment : PreferenceFragment() {
+class SecureSuspendFragment : BaseFragment() {
 
     private val switchBar: SwitchPreference
         get() = pref(R.string.pref_key_secure_suspend)

--- a/app/src/main/java/com/jmstudios/redmoon/SecureSuspendFragment.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/SecureSuspendFragment.kt
@@ -19,53 +19,28 @@ import com.jmstudios.redmoon.util.*
 
 class SecureSuspendFragment : PreferenceFragment() {
 
-    private val mSwitchBarPreference: SwitchPreference
-        get() = pref(R.string.pref_key_secure_suspend) as SwitchPreference
+    private val switchBar: SwitchPreference
+        get() = pref(R.string.pref_key_secure_suspend)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         Log.i("onCreate()")
         super.onCreate(savedInstanceState)
 
         addPreferencesFromResource(R.xml.secure_suspend_preferences)
-        setSwitchBarTitle(mSwitchBarPreference.isChecked)
 
-        mSwitchBarPreference.onPreferenceChangeListener =
-            Preference.OnPreferenceChangeListener { _, newValue ->
-                val on = newValue as Boolean
-                // TODO: Make this readable
-                if (!on) {
-                    setSwitchBarTitle(on)
-                    true
-                } else {
-                    val appChecker = CurrentAppChecker(appContext)
-                    if (!appChecker.isWorking) createEnableUsageStatsDialog()
-                    val working = appChecker.isWorking
-                    setSwitchBarTitle(working && on)
-                    working
-                }
+        setSwitchBarTitle(switchBar.isChecked)
+
+        switchBar.onPreferenceChangeListener =
+            Preference.OnPreferenceChangeListener { _, on ->
+                setSwitchBarTitle(on as Boolean)
+                true
             }
     }
 
     private fun setSwitchBarTitle(on: Boolean) {
-        mSwitchBarPreference.setTitle(
-                if (on) R.string.text_switch_on
-                else R.string.text_switch_off
-        )
+        val text = if (on) R.string.text_switch_on else R.string.text_switch_off
+        switchBar.setTitle(text)
     }
 
-    // TODO: Fix on API < 21
-    private fun createEnableUsageStatsDialog() {
-        AlertDialog.Builder(activity).apply {
-            setMessage(R.string.dialog_message_permission_usage_stats)
-            setTitle(R.string.dialog_title_permission_usage_stats)
-            setPositiveButton(R.string.dialog_button_ok) { _, _ ->
-                val intent = Intent(Settings.ACTION_USAGE_ACCESS_SETTINGS)
-                startActivityForResult(intent, RESULT_USAGE_ACCESS)
-            }
-        }.show()
-    }
-
-    companion object : Logger() {
-        const val RESULT_USAGE_ACCESS = 1
-    }
+    companion object : Logger()
 }

--- a/app/src/main/java/com/jmstudios/redmoon/filter/FilterService.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/filter/FilterService.kt
@@ -77,7 +77,6 @@ class FilterService : Service() {
             }
         } else {
             Log.i("Overlay permission denied.")
-            EventBus.post(overlayPermissionDenied())
             stopForeground(false)
         }
 

--- a/app/src/main/java/com/jmstudios/redmoon/filter/overlay/BrightnessManager.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/filter/overlay/BrightnessManager.kt
@@ -53,7 +53,6 @@ class BrightnessManager(context: Context) {
         set(lower) = when {
             !Permission.WriteSettings.isGranted -> {
                 Log.i("Permission not granted!")
-                EventBus.post(changeBrightnessDenied())
             } lower == brightnessLowered -> {
                 Log.i("Brightness already raised/lowered")
             } lower -> {

--- a/app/src/main/java/com/jmstudios/redmoon/preference/ProfileSelectorPreference.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/preference/ProfileSelectorPreference.kt
@@ -26,8 +26,6 @@ import com.jmstudios.redmoon.model.ProfilesModel
 import com.jmstudios.redmoon.model.ProfilesModel.isSaved
 import com.jmstudios.redmoon.util.*
 
-import org.greenrobot.eventbus.Subscribe
-
 class ProfileSelectorPreference(ctx: Context, attrs: AttributeSet) : Preference(ctx, attrs),
                                                                      OnItemSelectedListener {
     lateinit private var mProfileSpinner: Spinner
@@ -49,7 +47,7 @@ class ProfileSelectorPreference(ctx: Context, attrs: AttributeSet) : Preference(
         initLayout()
     }
 
-    private fun initLayout() {
+    fun initLayout() {
         Log.i("Starting initLayout")
         customShown = false
         mArrayAdapter = ArrayAdapter(context, android.R.layout.simple_spinner_item)
@@ -59,7 +57,7 @@ class ProfileSelectorPreference(ctx: Context, attrs: AttributeSet) : Preference(
         updateLayout()
     }
 
-    private fun updateLayout() {
+    fun updateLayout() {
         activeProfile.let {
             Log.i("Updating spinner. Active: $it; Custom: ${Config.custom}")
             if (it.isSaved) {
@@ -143,14 +141,6 @@ class ProfileSelectorPreference(ctx: Context, attrs: AttributeSet) : Preference(
 
     override fun onNothingSelected(parent: AdapterView<*>) { }
     //endregion
-
-    @Subscribe fun onProfileChanged(profile: Profile) {
-        updateLayout()
-    }
-
-    @Subscribe fun onProfilesChanged(event: profilesUpdated) {
-        initLayout()
-    }
 
     companion object : Logger()
 }

--- a/app/src/main/java/com/jmstudios/redmoon/util/Events.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/util/Events.kt
@@ -15,9 +15,3 @@ class useLocationChanged       : Event
 class locationChanged          : Event
 class secureSuspendChanged     : Event
 class buttonBacklightChanged   : Event
-
-class overlayPermissionDenied  : Event
-class locationAccessDenied     : Event
-class changeBrightnessDenied   : Event
-
-data class locationService(val isSearching: Boolean, val isRunning: Boolean = true) : Event

--- a/app/src/main/java/com/jmstudios/redmoon/util/Permission.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/util/Permission.kt
@@ -16,6 +16,7 @@ import android.support.v4.content.ContextCompat
 import android.support.v7.app.AlertDialog
 
 import com.jmstudios.redmoon.R
+import com.jmstudios.redmoon.util.Logger
 
 private const val REQ_CODE_OVERLAY  = 1111
 private const val REQ_CODE_LOCATION = 2222
@@ -31,14 +32,15 @@ abstract class PermissionHelper : EventBus.Event {
     }
 }
 
-object Permission {
+object Permission : Logger() {
     fun onRequestResult(requestCode: Int) {
-        EventBus.post(when (requestCode) {
-                          REQ_CODE_OVERLAY -> Overlay
-                          REQ_CODE_LOCATION -> Location
-                          REQ_CODE_SETTINGS -> WriteSettings
-                          else -> return@onRequestResult
-                      })
+        val name = when (requestCode) {
+            REQ_CODE_OVERLAY -> "Overlay"
+            REQ_CODE_LOCATION -> "Location"
+            REQ_CODE_SETTINGS -> "WriteSettings"
+            else -> "Invalid requestCode ($requestCode)"
+        }
+        Log.i("onRequestResult($name)")
     }
 
     object Location : PermissionHelper() {
@@ -71,14 +73,7 @@ object Permission {
         override @TargetApi(23) fun send(activity: Activity) {
             val intent = Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
                                 Uri.parse("package:" + activity.packageName))
-            AlertDialog.Builder(activity).run {
-                setMessage(R.string.dialog_message_permission_overlay)
-                setTitle(R.string.dialog_title_permission_overlay)
-                setPositiveButton(R.string.dialog_button_ok) { _, _ ->
-                    activity.startActivityForResult(intent, requestCode)
-                }
-                show()
-            }
+            activity.startActivityForResult(intent, requestCode)
         }
     }
 
@@ -91,14 +86,7 @@ object Permission {
         override @TargetApi(23) fun send(activity: Activity) {
             val intent = Intent(Settings.ACTION_MANAGE_WRITE_SETTINGS,
                                 Uri.parse("package:" + activity.packageName))
-            AlertDialog.Builder(activity).run {
-                setMessage(R.string.dialog_message_permission_write_settings)
-                setTitle(R.string.dialog_title_permission_write_settings)
-                setPositiveButton(R.string.dialog_button_ok) { _, _ ->
-                    activity.startActivityForResult(intent, requestCode)
-                }
-                show()
-            }
+            activity.startActivityForResult(intent, requestCode)
         }
     }
 }

--- a/app/src/main/java/com/jmstudios/redmoon/util/Util.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/util/Util.kt
@@ -68,6 +68,6 @@ fun belowAPI  (api: Int): Boolean = android.os.Build.VERSION.SDK_INT <  api
 fun intent() = Intent()
 fun <T: Any>intent(kc: KClass<T>) = Intent(appContext, kc.java)
 
-fun PreferenceFragment.pref(resId: Int): Preference {
-    return preferenceScreen.findPreference(getString(resId))
+inline fun <reified T: Preference>PreferenceFragment.pref(resId: Int): T {
+    return preferenceScreen.findPreference(getString(resId)) as T
 }

--- a/app/src/main/res/layout/preference_padding.xml
+++ b/app/src/main/res/layout/preference_padding.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ * Copyright (c) 2017 Stephen Michel <stephen.michel@tufts.edu>
+ * SPDX-License-Identifier: GPL3.0+
+-->
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="80dp"
+    >
+</LinearLayout>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -60,6 +60,7 @@
   <string name="pref_key_brightness_lowered" translatable="false">pref_key_brightness_lowered</string>
   <string name="pref_key_version" translatable="false">pref_key_version</string>
   <string name="pref_key_from_version_code" translatable="false">pref_key_from_version_code</string>
+  <string name="pref_key_padding" translatable="false">pref_key_padding</string>
 
   <!-- button_backlight_entries -->
   <string name="pref_value_button_backlight_system" translatable="false">system</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,6 +120,9 @@
     <string name="snackbar_searching_location">Searching for location</string>
     <string name="snackbar_location_updated">Found location!</string>
     <string name="help_snackbar_text">Press the switch to enable Red Moon</string>
+    <!-- This text is expected to take 2 lines in the snackbar -->
+    <string name="permission_snackbar_text">Some active features require additional permissions.</string>
+    <string name="permission_snackbar_action">Show</string>
 
     <!-- Dialog -->
     <string name="dialog_title_add_filter">Enter filter name</string>


### PR DESCRIPTION
When complete, this PR will close #114. Steps:

- [x] Remove all permission explanation dialogs
- [x] Allow enabling settings or even the filter when the relevant permissions are not granted
- [x] If relevant permissions are not granted, show a snackbar at the bottom, "Some features require additional permissions." It should have a single action, "Show". It will appear when:
  - [x] Overlay permission is not granted
  - [x] Any **currently enabled** feature requires additional permissions to work (app monitoring, sunrise-sunset schedule.
- [ ] "show" action opens a permission grant popup like acdisplay
- [ ] Enable app monitoring and sunrise-sunset schedule by default
- [ ] Squash commits