### PR TITLE
Upgrade to SDK 28

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,7 +38,7 @@ android {
     defaultConfig {
         applicationId "com.jmstudios.redmoon"
         minSdkVersion 14
-        targetSdkVersion 25
+        targetSdkVersion 28
         versionCode 37
         versionName "3.4.0"
     }
@@ -78,9 +78,9 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "com.android.support:support-compat:$android_support_version"
-    implementation "com.android.support:appcompat-v7:$android_support_version"
-    implementation "com.android.support:design:$android_support_version"
+    implementation 'androidx.core:core:1.0.0'
+    implementation 'androidx.appcompat:appcompat:1.0.0'
+    implementation 'com.google.android.material:material:1.0.0'
     implementation 'com.luckycatlabs:SunriseSunsetCalculator:1.2'
     implementation 'com.github.paolorotolo:appintro:4.1.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,7 +37,7 @@ android {
 
     defaultConfig {
         applicationId "com.jmstudios.redmoon"
-        minSdkVersion 14
+        minSdkVersion 23
         targetSdkVersion 28
         versionCode 37
         versionName "3.4.0"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -88,6 +88,9 @@ dependencies {
     implementation 'me.smichel.android:kpreferences:0.7.0'
     playstoreImplementation 'com.github.hotchemi:android-rate:1.0.1'
     // annotationProcessor 'org.greenrobot:eventbus-annotation-processor:3.0.1'
+
+    implementation "androidx.preference:preference:1.1.0-rc01"
+    implementation "androidx.preference:preference-ktx:1.1.0-rc01"
 }
 
 repositories {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,7 +37,7 @@ android {
 
     defaultConfig {
         applicationId "com.jmstudios.redmoon"
-        minSdkVersion 23
+        minSdkVersion 14
         targetSdkVersion 28
         versionCode 37
         versionName "3.4.0"

--- a/app/src/main/java/com/jmstudios/redmoon/AboutFragment.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/AboutFragment.kt
@@ -6,24 +6,20 @@
 package com.jmstudios.redmoon
 
 import android.os.Bundle
-import android.preference.Preference
-import android.preference.PreferenceFragment
+import androidx.preference.Preference
+import androidx.preference.PreferenceFragmentCompat
 
-import com.jmstudios.redmoon.BuildConfig
-import com.jmstudios.redmoon.R
 import com.jmstudios.redmoon.util.*
 
-class AboutFragment : PreferenceFragment() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        Log.i("onCreate()")
-        super.onCreate(savedInstanceState)
-        addPreferencesFromResource(R.xml.about)
-        pref(R.string.pref_key_version).apply{
+class AboutFragment : PreferenceFragmentCompat() {
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        setPreferencesFromResource(R.xml.about, rootKey)
+        pref(R.string.pref_key_version)?.apply{
             summary = BuildConfig.VERSION_NAME
-            onPreferenceClickListener = Preference.OnPreferenceClickListener {
-                showChangelog(activity)
+            Preference.OnPreferenceClickListener {
+                activity?.let { showChangelog(it) }
                 true
-            }
+            }?.let { onPreferenceClickListener = it }
         }
     }
     companion object : Logger()

--- a/app/src/main/java/com/jmstudios/redmoon/Changelog.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/Changelog.kt
@@ -8,7 +8,7 @@ package com.jmstudios.redmoon
 
 import android.app.Activity
 import android.app.Dialog
-import android.support.v7.app.AlertDialog
+import androidx.appcompat.app.AlertDialog
 
 import com.jmstudios.redmoon.model.Config
 

--- a/app/src/main/java/com/jmstudios/redmoon/FilterFragment.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/FilterFragment.kt
@@ -25,9 +25,9 @@
 package com.jmstudios.redmoon
 
 import android.os.Bundle
-import android.preference.Preference
-import android.preference.PreferenceFragment
-import android.preference.TwoStatePreference
+import androidx.preference.TwoStatePreference
+import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.Preference
 
 import com.jmstudios.redmoon.R
 
@@ -38,13 +38,13 @@ import com.jmstudios.redmoon.util.*
 
 import org.greenrobot.eventbus.Subscribe
 
-class FilterFragment : PreferenceFragment() {
+class FilterFragment : PreferenceFragmentCompat() {
     //private var hasShownWarningToast = false
     companion object : Logger()
 
     // Preferences
     private val profileSelectorPref: Preference
-        get() = pref(R.string.pref_key_profile_spinner)
+        get() = pref(R.string.pref_key_profile_spinner)!!
 
     private val colorPref: SeekBarPreference
         get() = pref(R.string.pref_key_color) as SeekBarPreference
@@ -59,17 +59,16 @@ class FilterFragment : PreferenceFragment() {
         get() = pref(R.string.pref_key_lower_brightness) as TwoStatePreference
 
     private val schedulePref: Preference
-        get() = pref(R.string.pref_key_schedule_header)
+        get() = pref(R.string.pref_key_schedule_header)!!
 
     private val secureSuspendPref: Preference
-        get() = pref(R.string.pref_key_secure_suspend_header)
+        get() = pref(R.string.pref_key_secure_suspend_header)!!
 
     private val buttonBacklightPref: Preference
-        get() = pref(R.string.pref_key_button_backlight)
+        get() = pref(R.string.pref_key_button_backlight)!!
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        addPreferencesFromResource(R.xml.filter_preferences)
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        setPreferencesFromResource(R.xml.filter_preferences, rootKey)
 
         updateSecureSuspendSummary()
         updateScheduleSummary()
@@ -82,7 +81,7 @@ class FilterFragment : PreferenceFragment() {
         lowerBrightnessPref.onPreferenceChangeListener =
                 Preference.OnPreferenceChangeListener { _, newValue ->
                     val checked = newValue as Boolean
-                    if (checked) Permission.WriteSettings.request(activity) else true
+                    if (checked) Permission.WriteSettings.request(requireActivity()) else true
                 }
 
         schedulePref.intent = intent(ScheduleActivity::class)

--- a/app/src/main/java/com/jmstudios/redmoon/Intro.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/Intro.kt
@@ -5,7 +5,7 @@
 package com.jmstudios.redmoon
 
 import android.os.Bundle
-import android.support.v4.app.Fragment
+import androidx.fragment.app.Fragment
 
 import com.github.paolorotolo.appintro.AppIntro2
 import com.github.paolorotolo.appintro.AppIntroFragment

--- a/app/src/main/java/com/jmstudios/redmoon/MainActivity.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/MainActivity.kt
@@ -28,7 +28,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
-import android.support.v7.widget.SwitchCompat
+import androidx.appcompat.widget.SwitchCompat
 
 import com.jmstudios.redmoon.R
 import com.jmstudios.redmoon.filter.Command

--- a/app/src/main/java/com/jmstudios/redmoon/RedMoonApplication.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/RedMoonApplication.kt
@@ -10,7 +10,7 @@ import com.jmstudios.redmoon.util.Logger
 
 import android.content.Context
 import android.content.SharedPreferences
-import android.preference.PreferenceManager
+import androidx.preference.PreferenceManager
 
 import com.jmstudios.redmoon.model.Config
 import com.jmstudios.redmoon.model.Profile

--- a/app/src/main/java/com/jmstudios/redmoon/ScheduleFragment.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/ScheduleFragment.kt
@@ -5,11 +5,13 @@
  */
 package com.jmstudios.redmoon
 
+import android.app.TimePickerDialog
 import android.os.Bundle
 import androidx.preference.SwitchPreference
 import com.google.android.material.snackbar.Snackbar
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 
 import com.jmstudios.redmoon.model.Config
@@ -34,7 +36,6 @@ class ScheduleFragment : PreferenceFragmentCompat() {
     private var mSnackbar: Snackbar? = null
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
-        super.onCreate(savedInstanceState)
         setPreferencesFromResource(R.xml.schedule_preferences, rootKey)
     }
 
@@ -54,6 +55,12 @@ class ScheduleFragment : PreferenceFragmentCompat() {
         updateSwitchBarTitle()
         updateTimePrefs()
         updateLocationPref()
+    }
+
+    override fun onDisplayPreferenceDialog(preference: Preference?) {
+        TimePickerDialog(context, { _, h, m ->
+            preference?.callChangeListener(Time(h, m))
+        },0, 0, false).show()
     }
 
     private fun updateSwitchBarTitle() {

--- a/app/src/main/java/com/jmstudios/redmoon/ScheduleFragment.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/ScheduleFragment.kt
@@ -8,11 +8,9 @@ package com.jmstudios.redmoon
 import android.os.Bundle
 import android.preference.PreferenceFragment
 import android.preference.SwitchPreference
-import android.support.design.widget.Snackbar
+import com.google.android.material.snackbar.Snackbar
 import android.view.ViewGroup
 import android.widget.TextView
-
-import com.jmstudios.redmoon.R
 
 import com.jmstudios.redmoon.model.Config
 import com.jmstudios.redmoon.schedule.*
@@ -97,10 +95,8 @@ class ScheduleFragment : PreferenceFragment() {
             if (Config.darkThemeFlag) {
                 val group = this.view as ViewGroup
                 group.setBackgroundColor(getColor(R.color.snackbar_color_dark_theme))
-
-                val snackbarTextId = android.support.design.R.id.snackbar_text
-                val textView = group.findViewById<TextView>(snackbarTextId)
-                textView.setTextColor(getColor(R.color.text_color_dark_theme))
+                group.findViewById<TextView>(R.id.snackbar_text)
+                    .setTextColor(getColor(R.color.text_color_dark_theme))
             }
         }
         mSnackbar?.show()

--- a/app/src/main/java/com/jmstudios/redmoon/ScheduleFragment.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/ScheduleFragment.kt
@@ -6,11 +6,11 @@
 package com.jmstudios.redmoon
 
 import android.os.Bundle
-import android.preference.PreferenceFragment
-import android.preference.SwitchPreference
+import androidx.preference.SwitchPreference
 import com.google.android.material.snackbar.Snackbar
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.preference.PreferenceFragmentCompat
 
 import com.jmstudios.redmoon.model.Config
 import com.jmstudios.redmoon.schedule.*
@@ -18,9 +18,7 @@ import com.jmstudios.redmoon.util.*
 
 import org.greenrobot.eventbus.Subscribe
 
-class ScheduleFragment : PreferenceFragment() {
-
-    // Preferences
+class ScheduleFragment : PreferenceFragmentCompat() {
     private val schedulePref: SwitchPreference
         get() = pref(R.string.pref_key_schedule) as SwitchPreference
 
@@ -35,9 +33,9 @@ class ScheduleFragment : PreferenceFragment() {
 
     private var mSnackbar: Snackbar? = null
 
-    override fun onCreate(savedInstanceState: Bundle?) {
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         super.onCreate(savedInstanceState)
-        addPreferencesFromResource(R.xml.schedule_preferences)
+        setPreferencesFromResource(R.xml.schedule_preferences, rootKey)
     }
 
     override fun onStart() {
@@ -91,12 +89,12 @@ class ScheduleFragment : PreferenceFragment() {
     }
 
     private fun showSnackbar(resId: Int, duration: Int = Snackbar.LENGTH_INDEFINITE) {
-        mSnackbar = Snackbar.make(view, getString(resId), duration).apply {
+        mSnackbar = Snackbar.make(requireView(), getString(resId), duration).apply {
             if (Config.darkThemeFlag) {
                 val group = this.view as ViewGroup
                 group.setBackgroundColor(getColor(R.color.snackbar_color_dark_theme))
                 group.findViewById<TextView>(R.id.snackbar_text)
-                    .setTextColor(getColor(R.color.text_color_dark_theme))
+                        .setTextColor(getColor(R.color.text_color_dark_theme))
             }
         }
         mSnackbar?.show()
@@ -141,7 +139,7 @@ class ScheduleFragment : PreferenceFragment() {
     @Subscribe
     fun onLocationAccessDenied(event: locationAccessDenied) {
         if (Config.scheduleOn && Config.useLocation) {
-            Permission.Location.request(activity)
+            Permission.Location.request(requireActivity())
         }
     }
 

--- a/app/src/main/java/com/jmstudios/redmoon/SecureSuspendFragment.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/SecureSuspendFragment.kt
@@ -8,9 +8,9 @@ package com.jmstudios.redmoon
 import android.app.AlertDialog
 import android.content.Intent
 import android.os.Bundle
-import android.preference.Preference
-import android.preference.SwitchPreference
 import android.provider.Settings
+import androidx.preference.Preference
+import androidx.preference.SwitchPreference
 import androidx.preference.PreferenceFragmentCompat
 
 import com.jmstudios.redmoon.securesuspend.CurrentAppChecker

--- a/app/src/main/java/com/jmstudios/redmoon/SecureSuspendFragment.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/SecureSuspendFragment.kt
@@ -6,29 +6,24 @@
 package com.jmstudios.redmoon
 
 import android.app.AlertDialog
-import android.preference.PreferenceFragment
 import android.content.Intent
 import android.os.Bundle
 import android.preference.Preference
 import android.preference.SwitchPreference
 import android.provider.Settings
+import androidx.preference.PreferenceFragmentCompat
 
 import com.jmstudios.redmoon.securesuspend.CurrentAppChecker
-import com.jmstudios.redmoon.R
 import com.jmstudios.redmoon.util.*
 
-class SecureSuspendFragment : PreferenceFragment() {
+class SecureSuspendFragment : PreferenceFragmentCompat() {
 
     private val mSwitchBarPreference: SwitchPreference
         get() = pref(R.string.pref_key_secure_suspend) as SwitchPreference
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        Log.i("onCreate()")
-        super.onCreate(savedInstanceState)
-
-        addPreferencesFromResource(R.xml.secure_suspend_preferences)
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        setPreferencesFromResource(R.xml.secure_suspend_preferences, rootKey)
         setSwitchBarTitle(mSwitchBarPreference.isChecked)
-
         mSwitchBarPreference.onPreferenceChangeListener =
             Preference.OnPreferenceChangeListener { _, newValue ->
                 val on = newValue as Boolean

--- a/app/src/main/java/com/jmstudios/redmoon/ThemedAppCompatActivity.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/ThemedAppCompatActivity.kt
@@ -6,9 +6,9 @@
 package com.jmstudios.redmoon
 
 import android.os.Bundle
-import android.preference.PreferenceFragment
 import androidx.appcompat.app.AppCompatActivity
 import android.view.MenuItem
+import androidx.preference.PreferenceFragmentCompat
 
 import com.jmstudios.redmoon.R
 
@@ -17,22 +17,22 @@ import com.jmstudios.redmoon.util.*
 
 abstract class ThemedAppCompatActivity : AppCompatActivity() {
 
-    protected abstract val fragment: PreferenceFragment
+    protected abstract val fragment: PreferenceFragmentCompat
     protected abstract val tag: String
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
         setTheme(Config.activeTheme)
         setContentView(R.layout.activity_main)
 
         // Only create and attach a new fragment on the first Activity creation.
         if (savedInstanceState == null) {
             Log.i("onCreate - First creation")
-            fragmentManager.beginTransaction()
-                           .replace(R.id.fragment_container, fragment, tag)
-                           .commit()
+            supportFragmentManager
+                .beginTransaction()
+                .replace(R.id.fragment_container, fragment, tag)
+                .commit()
         }
-
-        super.onCreate(savedInstanceState)
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/app/src/main/java/com/jmstudios/redmoon/ThemedAppCompatActivity.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/ThemedAppCompatActivity.kt
@@ -7,7 +7,7 @@ package com.jmstudios.redmoon
 
 import android.os.Bundle
 import android.preference.PreferenceFragment
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.view.MenuItem
 
 import com.jmstudios.redmoon.R

--- a/app/src/main/java/com/jmstudios/redmoon/filter/Notification.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/filter/Notification.kt
@@ -11,8 +11,8 @@ import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
-import android.support.v4.app.NotificationCompat
-import android.support.v4.content.ContextCompat
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
 
 import com.jmstudios.redmoon.R
 import com.jmstudios.redmoon.MainActivity

--- a/app/src/main/java/com/jmstudios/redmoon/filter/overlay/BrightnessManager.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/filter/overlay/BrightnessManager.kt
@@ -38,7 +38,7 @@ class BrightnessManager(private val context: Context) {
     private var level: Int
         get() = Settings.System.getInt(resolver, Settings.System.SCREEN_BRIGHTNESS)
         set(value) {
-            if (Settings.System.canWrite(context)) {
+            if (belowAPI(23) || Settings.System.canWrite(context)) {
                 Settings.System.putInt(resolver, Settings.System.SCREEN_BRIGHTNESS, value)
             } else {
                 Log.w("Write settings permission not granted; cannot set brightness")

--- a/app/src/main/java/com/jmstudios/redmoon/filter/overlay/Overlay.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/filter/overlay/Overlay.kt
@@ -62,8 +62,8 @@ class Overlay(context: Context) : View(context), Filter,
         filtering = false
     }
 
-    private var filtering: Boolean by Delegates.observable(false) {
-        _, isOn, turnOn -> when {
+    private var filtering: Boolean by Delegates.observable(false) { _, isOn, turnOn ->
+        when {
             !isOn && turnOn -> show()
             isOn && !turnOn -> hide()
             isOn && turnOn -> update()
@@ -94,7 +94,14 @@ class Overlay(context: Context) : View(context), Filter,
     }
 
     private var mLayoutParams = mScreenManager.layoutParams
-        get() = field.apply { buttonBrightness = Config.buttonBacklightLevel }
+        get() = field.apply {
+            buttonBrightness = Config.buttonBacklightLevel
+            type = if (atLeastAPI(26)) {
+                WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY
+            } else {
+                WindowManager.LayoutParams.TYPE_SYSTEM_OVERLAY
+            }
+        }
 
     private fun updateLayoutParams() {
         mLayoutParams = mScreenManager.layoutParams

--- a/app/src/main/java/com/jmstudios/redmoon/preference/ProfileSelectorPreference.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/preference/ProfileSelectorPreference.kt
@@ -7,7 +7,6 @@ package com.jmstudios.redmoon.preference
 
 import android.app.AlertDialog
 import android.content.Context
-import android.preference.Preference
 import android.text.InputType
 import android.util.AttributeSet
 import android.view.View
@@ -17,6 +16,8 @@ import android.widget.ArrayAdapter
 import android.widget.Button
 import android.widget.EditText
 import android.widget.Spinner
+import androidx.preference.Preference
+import androidx.preference.PreferenceViewHolder
 
 import com.jmstudios.redmoon.R
 
@@ -39,12 +40,10 @@ class ProfileSelectorPreference(ctx: Context, attrs: AttributeSet) : Preference(
         layoutResource = R.layout.preference_profile_selector
     }
 
-    override fun onBindView(view: View) {
-        Log.i("onBindView")
-        super.onBindView(view)
-
-        mProfileSpinner = view.findViewById(R.id.profile_spinner)
-        mProfileActionButton = view.findViewById(R.id.profile_action_button)
+    override fun onBindViewHolder(holder: PreferenceViewHolder?) {
+        super.onBindViewHolder(holder)
+        mProfileSpinner = holder?.findViewById(R.id.profile_spinner) as Spinner
+        mProfileActionButton = holder?.findViewById(R.id.profile_action_button) as Button
 
         initLayout()
     }

--- a/app/src/main/java/com/jmstudios/redmoon/preference/SeekBarPreference.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/preference/SeekBarPreference.kt
@@ -9,12 +9,13 @@ import android.content.Context
 import android.content.res.TypedArray
 import android.graphics.PorterDuff
 import android.graphics.PorterDuffColorFilter
-import android.preference.Preference
 import android.util.AttributeSet
 import android.view.View
 import android.widget.ImageView
 import android.widget.SeekBar
 import android.widget.TextView
+import androidx.preference.PreferenceViewHolder
+import androidx.preference.Preference
 
 import com.jmstudios.redmoon.R
 
@@ -55,11 +56,11 @@ abstract class SeekBarPreference(context: Context, attrs: AttributeSet) : Prefer
         }
     }
 
-    override fun onBindView(view: View) {
+    override fun onBindViewHolder(holder: PreferenceViewHolder) {
         Log.i("onBindView")
-        super.onBindView(view)
-        mView = view
-        mSeekBar = view.findViewById(R.id.seekbar)
+        super.onBindViewHolder(holder)
+        mView = holder.itemView
+        mSeekBar = holder.findViewById(R.id.seekbar) as SeekBar
         setProgress(mProgress)
         mSeekBar.setMax(max)
         mSeekBar.setOnSeekBarChangeListener(this)

--- a/app/src/main/java/com/jmstudios/redmoon/schedule/ScheduleReceiver.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/schedule/ScheduleReceiver.kt
@@ -11,7 +11,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import android.support.v4.app.AlarmManagerCompat
+import androidx.core.app.AlarmManagerCompat
 
 import com.jmstudios.redmoon.filter.Command
 import com.jmstudios.redmoon.model.Config

--- a/app/src/main/java/com/jmstudios/redmoon/util/Permission.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/util/Permission.kt
@@ -11,9 +11,9 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.provider.Settings
-import android.support.v4.app.ActivityCompat
-import android.support.v4.content.ContextCompat
-import android.support.v7.app.AlertDialog
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import androidx.appcompat.app.AlertDialog
 
 import com.jmstudios.redmoon.R
 

--- a/app/src/main/java/com/jmstudios/redmoon/util/Util.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/util/Util.kt
@@ -25,9 +25,9 @@
 package com.jmstudios.redmoon.util
 
 import android.content.Intent
-import android.preference.Preference
-import android.preference.PreferenceFragment
+import androidx.preference.Preference
 import androidx.core.content.ContextCompat
+import androidx.preference.PreferenceFragmentCompat
 
 import com.jmstudios.redmoon.RedMoonApplication
 import com.jmstudios.redmoon.model.Profile
@@ -68,6 +68,6 @@ fun belowAPI  (api: Int): Boolean = android.os.Build.VERSION.SDK_INT <  api
 fun intent() = Intent()
 fun <T: Any>intent(kc: KClass<T>) = Intent(appContext, kc.java)
 
-fun PreferenceFragment.pref(resId: Int): Preference {
+fun PreferenceFragmentCompat.pref(resId: Int): Preference? {
     return preferenceScreen.findPreference(getString(resId))
 }

--- a/app/src/main/java/com/jmstudios/redmoon/util/Util.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/util/Util.kt
@@ -27,7 +27,7 @@ package com.jmstudios.redmoon.util
 import android.content.Intent
 import android.preference.Preference
 import android.preference.PreferenceFragment
-import android.support.v4.content.ContextCompat
+import androidx.core.content.ContextCompat
 
 import com.jmstudios.redmoon.RedMoonApplication
 import com.jmstudios.redmoon.model.Profile

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -16,7 +16,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
-    <android.support.design.widget.FloatingActionButton
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
         xmlns:app="http://schemas.android.com/apk/res-auto"
         android:id="@+id/toggle_fab"
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/preference_profile_selector.xml
+++ b/app/src/main/res/layout/preference_profile_selector.xml
@@ -13,7 +13,7 @@
     android:layout_height="wrap_content"
     android:orientation="horizontal" >
 
-  <android.support.v7.widget.AppCompatSpinner
+  <androidx.appcompat.widget.AppCompatSpinner
       android:id="@+id/profile_spinner"
       android:layout_width="0dp"
       android:layout_height="wrap_content"

--- a/app/src/main/res/layout/preferences_category.xml
+++ b/app/src/main/res/layout/preferences_category.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@android:id/title"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:textStyle="bold"
+    android:paddingTop="16dp"
+    android:paddingBottom="16dp"
+    android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+    android:paddingLeft="?android:attr/listPreferredItemPaddingLeft"
+    android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
+    android:paddingRight="?android:attr/listPreferredItemPaddingRight"
+    android:textColor="?android:attr/colorAccent"
+    />

--- a/app/src/main/res/layout/preferences_category.xml
+++ b/app/src/main/res/layout/preferences_category.xml
@@ -3,12 +3,11 @@
     android:id="@android:id/title"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:textStyle="bold"
     android:paddingTop="16dp"
     android:paddingBottom="16dp"
     android:paddingStart="?android:attr/listPreferredItemPaddingStart"
     android:paddingLeft="?android:attr/listPreferredItemPaddingLeft"
     android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
     android:paddingRight="?android:attr/listPreferredItemPaddingRight"
-    android:textColor="?android:attr/colorAccent"
-    />
+    android:textColor="@color/color_accent"
+    android:textStyle="bold" />

--- a/app/src/main/res/layout/switch_bar.xml
+++ b/app/src/main/res/layout/switch_bar.xml
@@ -10,7 +10,7 @@
     android:minHeight="?android:attr/actionBarSize"
     android:gravity="center_vertical"
     android:background="@color/switch_bar_background">
-    <android.support.v7.widget.AppCompatTextView
+    <androidx.appcompat.widget.AppCompatTextView
         android:id="@android:id/title"
         android:layout_height="wrap_content"
         android:layout_width="0dp"

--- a/app/src/main/res/layout/switch_layout.xml
+++ b/app/src/main/res/layout/switch_layout.xml
@@ -3,7 +3,7 @@
  * Copyright (c) 2016 Marien Raat <marienraat@riseup.net>
  * SPDX-License-Identifier: GPL3.0+
 -->
-<android.support.v7.widget.SwitchCompat
+<androidx.appcompat.widget.SwitchCompat
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/switch_for_action_bar"
     android:layout_width="wrap_content"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -27,6 +27,7 @@
     <color name="color_primary">#FFF44336</color>
     <color name="color_primary_dark">#D32F2F</color>
     <color name="color_white">#FFFFFFFF</color>
+    <color name="color_accent">#008577</color>
     <color name="fab_color">#FFF44336</color>
     <color name="text_disabled">#909090</color>
     <color name="snackbar_color_dark_theme">#FAFAFA</color>

--- a/app/src/main/res/xml/filter_preferences.xml
+++ b/app/src/main/res/xml/filter_preferences.xml
@@ -25,7 +25,7 @@
 -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
-  <PreferenceCategory android:title="@string/pref_category_filter">
+  <PreferenceCategory android:title="@string/pref_category_filter" android:layout="@layout/preferences_category">
     <com.jmstudios.redmoon.preference.ProfileSelectorPreference
         android:key="@string/pref_key_profile_spinner"
         android:persistent="false"/>

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath 'com.android.tools.build:gradle:3.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.20.0'
         classpath "org.ajoberstar.grgit:grgit-core:$grgit_version"

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,5 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+android.enableJetifier=true
+android.useAndroidX=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jan 24 11:39:37 EST 2019
+#Sat Aug 17 22:04:47 EDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip


### PR DESCRIPTION
- Jetpackifies the app via Android Studio's auto-migration
- Migrates from the deprecated `android.preferences` libraries to `androidx.preferences`
- Mildly refactors the TimePicker dialogue settings.

Tested on a real device running 8.1.0, and AVDs running 8.0, 6.0, 5.1, 4.3, 4.1, and 4.0.

Resolves #242; Resolves #259 