### PR TITLE
fix crash when starting FilterService from a quick setting tile

### DIFF
--- a/app/src/main/java/com/jmstudios/redmoon/filter/Command.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/filter/Command.kt
@@ -8,6 +8,7 @@ package com.jmstudios.redmoon.filter
 
 import android.content.ComponentName
 import android.content.Intent
+import android.os.Build
 
 import com.jmstudios.redmoon.util.*
 
@@ -68,7 +69,18 @@ enum class Command(val time: Float) {
     val intent: Intent
         get() = intent(FilterService::class).putExtra(EXTRA_COMMAND, name)
 
-    fun send(): ComponentName? = appContext.startService(intent)
+    fun send(): ComponentName? {
+        // Starting from SDK 26, startService doesn't allow to start a
+        // foreground service from background. Most of the time, FilterService
+        // is started from foreground anyways but there are exceptions: for
+        // instance when launched from a quick setting tile.
+        // See https://developer.android.com/about/versions/oreo/background
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            appContext.startForegroundService(intent)
+        } else {
+            appContext.startService(intent)
+        }
+    }
 
     abstract val turnOn: Boolean
 


### PR DESCRIPTION
When launching FilterService from a quick setting tile with Red Moon shut, the service would fail to start on recent Android versions with the following traceback:

```
02-17 10:26:47.938  1442  2008 W ActivityManager: Background start not allowed: service Intent { cmp=com.jmstudios.redmoon/.filter.FilterService (has extras) } to com.jmstudios.redmoon/.filter.FilterService from pid=18936 uid=10077 pkg=com.jmstudios.redmoon startFg?=false
02-17 10:26:47.939 18936 18936 D AndroidRuntime: Shutting down VM
02-17 10:26:47.940 18936 18936 E AndroidRuntime: FATAL EXCEPTION: main
02-17 10:26:47.940 18936 18936 E AndroidRuntime: Process: com.jmstudios.redmoon, PID: 18936
02-17 10:26:47.940 18936 18936 E AndroidRuntime: java.lang.IllegalStateException: Not allowed to start service Intent { cmp=com.jmstudios.redmoon/.filter.FilterService (has extras) }: app is in background uid UidRecord{69dcdfc u0a77 CEM  idle change:cached procs:1 seq(0,0,0)}
02-17 10:26:47.940 18936 18936 E AndroidRuntime: 	at android.app.ContextImpl.startServiceCommon(ContextImpl.java:1715)
02-17 10:26:47.940 18936 18936 E AndroidRuntime: 	at android.app.ContextImpl.startService(ContextImpl.java:1670)
02-17 10:26:47.940 18936 18936 E AndroidRuntime: 	at android.content.ContextWrapper.startService(ContextWrapper.java:720)
02-17 10:26:47.940 18936 18936 E AndroidRuntime: 	at com.jmstudios.redmoon.filter.Command.send(Command.kt:71)
02-17 10:26:47.940 18936 18936 E AndroidRuntime: 	at com.jmstudios.redmoon.filter.Command$Companion.toggle(Command.kt:94)
02-17 10:26:47.940 18936 18936 E AndroidRuntime: 	at com.jmstudios.redmoon.widget.TileReceiver.onClick(TileReceiver.kt:27)
02-17 10:26:47.940 18936 18936 E AndroidRuntime: 	at android.service.quicksettings.TileService$H.handleMessage(TileService.java:449)
02-17 10:26:47.940 18936 18936 E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:106)
02-17 10:26:47.940 18936 18936 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:223)
02-17 10:26:47.940 18936 18936 E AndroidRuntime: 	at android.app.ActivityThread.main(ActivityThread.java:7660)
02-17 10:26:47.940 18936 18936 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
02-17 10:26:47.940 18936 18936 E AndroidRuntime: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
02-17 10:26:47.940 18936 18936 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
```

This is because recent versions of Android disallow starting a foreground services using `startService` directly. You have to use `startForegroundService` and ensure the started service calls `startForeground` 5 seconds at most after the service is started. This behavior change is documented [here](https://developer.android.com/about/versions/oreo/android-8.0-changes).

Let me know if you think any improvement should be made.