### PR TITLE
(4 years late, but) Feature: Add root mode [#150]

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,6 +38,10 @@ android {
         versionCode 38
         versionName "3.5.0"
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
     buildTypes {
         release {
             minifyEnabled false
@@ -81,6 +85,7 @@ dependencies {
     implementation 'com.luckycatlabs:SunriseSunsetCalculator:1.2'
     implementation 'com.github.paolorotolo:appintro:4.1.0'
     implementation 'org.greenrobot:eventbus:3.2.0'
+    implementation 'com.github.topjohnwu.libsu:core:3.1.1'
     // annotationProcessor 'org.greenrobot:eventbus-annotation-processor:3.0.1'
 
 }

--- a/app/src/main/java/com/jmstudios/redmoon/FilterFragment.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/FilterFragment.kt
@@ -75,7 +75,7 @@ class FilterFragment : PreferenceFragmentCompat() {
     override fun onStart() {
         Log.i("onStart")
         super.onStart()
-        preferenceScreen.setEnabled(Permission.Overlay.isGranted)
+        preferenceScreen.setEnabled(Permission.Overlay.isGranted || Config.useRoot)
         EventBus.register(profileSelectorPref)
         EventBus.register(this)
     }

--- a/app/src/main/java/com/jmstudios/redmoon/Intro.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/Intro.kt
@@ -12,6 +12,7 @@ import com.github.paolorotolo.appintro.AppIntroFragment
 
 import com.jmstudios.redmoon.R
 import com.jmstudios.redmoon.model.Config
+import com.topjohnwu.superuser.Shell
 
 class Intro : AppIntro2() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -53,6 +54,7 @@ class Intro : AppIntro2() {
 
     private fun saveAndFinish() {
         Config.introShown = true
+        Shell.rootAccess()
         finish()
     }
 }

--- a/app/src/main/java/com/jmstudios/redmoon/filter/surfaceflinger/SurfaceFlinger.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/filter/surfaceflinger/SurfaceFlinger.kt
@@ -1,0 +1,63 @@
+package com.jmstudios.redmoon.filter.surfaceflinger
+
+import android.graphics.Color
+import com.jmstudios.redmoon.filter.Filter
+import com.jmstudios.redmoon.util.*
+import com.topjohnwu.superuser.Shell
+import kotlin.properties.Delegates
+
+class SurfaceFlinger() : Filter {
+    private var filtering: Boolean by Delegates.observable(false) { _, isOn, turnOn ->
+        when {
+            !isOn && turnOn -> show()
+            isOn && !turnOn -> hide()
+            isOn && turnOn -> update()
+        }
+    }
+
+    private fun show() {
+
+    }
+
+    private fun hide() {
+        val call = "service call SurfaceFlinger 1015 i32 1 " +
+                "f 1 f  0 f  0 f  0 " +
+                "f  0 f 1 f  0 f  0 " +
+                "f  0 f  0 f 1 f  0 " +
+                "f  0 f  0 f  0 f  1"
+        Log.d(call)
+        Shell.su(call).exec()
+    }
+
+    private fun update() {
+        val color = activeProfile.multFilterColor
+        val r = Color.red(color) / 255.0f
+        val g = Color.green(color) / 255.0f
+        val b = Color.blue(color) / 255.0f
+        Log.i("Set to $r $g $b")
+        val call = "service call SurfaceFlinger 1015 i32 1 " +
+                "f $r f  0 f  0 f  0 " +
+                "f  0 f $g f  0 f  0 " +
+                "f  0 f  0 f $b f  0 " +
+                "f  0 f  0 f  0 f  1"
+        Log.d(call)
+        Shell.su(call).exec()
+    }
+
+    override fun onCreate() {
+
+    }
+
+    override fun onDestroy() {
+
+    }
+
+    override var profile = activeProfile.off
+    set(value) {
+        Log.i("profile set to: $value")
+        field = value
+        filtering = !value.isOff
+    }
+
+    companion object : Logger()
+}

--- a/app/src/main/java/com/jmstudios/redmoon/model/Config.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/model/Config.kt
@@ -205,6 +205,8 @@ object Config : Preferences(appContext) {
             "dim" -> 1 - (dimLevel.toFloat() / 100)
             else -> 0.toFloat()
         }
+
+    var useRoot by BooleanPreference(R.string.pref_key_use_root, false)
     //endregion
 
     //region application

--- a/app/src/main/java/com/jmstudios/redmoon/model/Profile.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/model/Profile.kt
@@ -51,6 +51,17 @@ data class Profile(
     val name: String
         get() = ProfilesModel.nameOf(this) ?: getString(R.string.filter_name_custom)
 
+    val multFilterColor: Int
+        get() {
+            val rgbColor = rgbFromColor(color)
+            val intensityColor = intensity / 100.0f
+            val dim = dimLevel / 100.0f
+            return Color.argb(255,
+                    Math.round((Color.red(rgbColor) * intensityColor + 255.0f * (1.0f - intensityColor)) * (1.0f - dim)),
+                    Math.round((Color.green(rgbColor) * intensityColor + 255.0f * (1.0f - intensityColor)) * (1.0f - dim)),
+                    Math.round((Color.blue(rgbColor) * intensityColor + 255.0f * (1.0f - intensityColor)) * (1.0f - dim)))
+        }
+
     val filterColor: Int
         get() {
             val rgbColor = rgbFromColor(color)

--- a/app/src/main/java/com/jmstudios/redmoon/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/settings/SettingsFragment.kt
@@ -20,6 +20,7 @@ import com.jmstudios.redmoon.filter.Command
 import com.jmstudios.redmoon.model.Config
 import com.jmstudios.redmoon.schedule.*
 import com.jmstudios.redmoon.util.*
+import com.topjohnwu.superuser.Shell
 
 import org.greenrobot.eventbus.Subscribe
 import org.libreshift.preferences.TimePreference
@@ -40,6 +41,9 @@ class SettingsFragment : PreferenceFragmentCompat() {
 
     private val themePref: SwitchPreference
         get() = pref(R.string.pref_key_dark_theme) as SwitchPreference
+
+    private val rootPref: SwitchPreference
+        get() = pref(R.string.pref_key_use_root) as SwitchPreference
 
     private var mSnackbar: Snackbar? = null
 
@@ -95,6 +99,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
         updatePrefs()
         EventBus.register(this)
         LocationUpdateService.update()
+        rootPref.isVisible = Shell.rootAccess()
     }
 
     override fun onStop() {

--- a/app/src/main/java/com/jmstudios/redmoon/util/Permission.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/util/Permission.kt
@@ -16,6 +16,7 @@ import androidx.core.content.ContextCompat
 import androidx.appcompat.app.AlertDialog
 
 import com.jmstudios.redmoon.R
+import com.jmstudios.redmoon.model.Config
 
 private const val REQ_CODE_OVERLAY  = 1111
 private const val REQ_CODE_LOCATION = 2222

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -127,4 +127,5 @@
     <string name="pref_summary_start_time_sunset">Auringonlasku (%s)</string>
     <string name="pref_value_stop_time_sunrise">Auringonnousu</string>
     <string name="pref_summary_stop_time_sunrise">Auringonnousu (%s)</string>
+    <string name="pref_title_use_root">Käyttää pääkäyttäjä</string>
 </resources>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -25,6 +25,7 @@
 -->
 <resources>
   <!-- Preference Keys -->
+  <string name="pref_key_use_root" translatable="false">pref_key_use_root</string>
   <string name="pref_key_profile_spinner" translatable="false">pref_key_profile_spinner</string>
   <string name="pref_key_dim" translatable="false">pref_key_shades_dim_level</string>
   <string name="pref_key_intensity" translatable="false">pref_key_shades_intensity_level</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -88,6 +88,7 @@
     <string name="pref_summary_use_location">Based on your location</string>
     <string name="pref_title_location">Location</string>
     <string name="pref_title_dark_theme">Dark theme</string>
+    <string name="pref_title_use_root">Use root</string>
 
     <string name="pref_summary_secure_suspend">When this feature is enabled, Red Moon will automatically pause when certain apps are open. By default, this includes apps that won\'t work when Red Moon is running*, like installing apks. You can change this behavior for the current screen of the current app from the notification. For example, you might want to add color-sensitive apps, like the camera.\n\nThis feature may slightly lower the battery life of your device.\n\n*Some apps are secured against overlays to protect themselves from interference, like tricking you into installing an app you don\'t want. They won\'t respond to touches when Red Moon is on, since it works by drawing a transparent red layer over the screen.</string>
 

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -49,6 +49,12 @@
             android:key="@string/pref_key_dark_theme"
             android:title="@string/pref_title_dark_theme"
             android:defaultValue="false" />
+        <SwitchPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="false"
+            android:key="@string/pref_key_use_root"
+            android:title="@string/pref_title_use_root" />
 
     </PreferenceCategory>
 

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ allprojects {
     repositories {
         jcenter()
         google()
+        maven { url 'https://jitpack.io' }
     }
 }
 


### PR DESCRIPTION
NOTE: The UX for this is still pretty janky, users with rooted phones
will be asked for root upon the initial setup ending, which will show a
"use root" option in the settings menu.

You _must_ restart the app after toggling the "use root" option or
things will not work properly