### PR TITLE
Update to Android 12

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -4,15 +4,14 @@ on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
-    - name: set up JDK 1.8
-      uses: actions/setup-java@v1
+    - name: set up JDK 11
+      uses: actions/setup-java@v2
       with:
-        java-version: 1.8
+        distribution: 'zulu'
+        java-version: '11'
     - name: Validate Gradle Wrapper
       uses: gradle/wrapper-validation-action@v1
     - name: Clean Gradle

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,13 +28,12 @@ if(rootProject.file("keystore.properties").exists()) {
 }
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion '29.0.2'
+    compileSdkVersion 32
 
     defaultConfig {
         applicationId "com.jmstudios.redmoon"
         minSdkVersion 14
-        targetSdkVersion 29
+        targetSdkVersion 32
         versionCode 38
         versionName "3.5.0"
     }
@@ -62,23 +61,22 @@ android {
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
-    lintOptions {
-        disable 'NewApi','ExpiredTargetSdkVersion'
+    lint {
+        disable 'NewApi', 'ExpiredTargetSdkVersion'
     }
 }
 
 dependencies {
     // Android/platform deps
-    implementation 'androidx.core:core:1.3.2'
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
-    implementation 'androidx.preference:preference:1.1.1'
-    implementation 'androidx.preference:preference-ktx:1.1.1'
-    implementation 'com.google.android.material:material:1.2.1'
+    implementation 'androidx.core:core:1.7.0'
+    implementation 'androidx.appcompat:appcompat:1.4.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
+    implementation 'androidx.preference:preference:1.2.0'
+    implementation 'androidx.preference:preference-ktx:1.2.0'
+    implementation 'com.google.android.material:material:1.5.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     // Written by me
-    implementation "me.smichel.android:kpreferences:0.7.0"
     implementation project(":timepickerpreference")
 
     // 3rd party

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,7 +44,9 @@
     <uses-permission
         android:name="android.permission.WRITE_SETTINGS"
         tools:ignore="ProtectedPermissions" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.GET_TASKS" />
     <uses-permission
         android:name="android.permission.PACKAGE_USAGE_STATS"
@@ -66,7 +68,8 @@
 
         <activity
             android:name="com.jmstudios.redmoon.activity.MainActivity"
-            android:label="@string/activity_main">
+            android:label="@string/activity_main"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -103,27 +106,28 @@
         <activity
             android:name=".widget.ShortcutCreationActivity"
             android:label="@string/activity_shortcut"
-            android:theme="@style/TransparentTheme">
+            android:theme="@style/TransparentTheme"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.CREATE_SHORTCUT" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
 
-        <receiver android:name="com.jmstudios.redmoon.receiver.BootReceiver">
+        <receiver android:name="com.jmstudios.redmoon.receiver.BootReceiver" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <action android:name="android.intent.action.QUICKBOOT_POWERON" />
             </intent-filter>
         </receiver>
 
-        <receiver android:name="com.jmstudios.redmoon.receiver.TimeZoneChangeReceiver">
+        <receiver android:name="com.jmstudios.redmoon.receiver.TimeZoneChangeReceiver" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.TIMEZONE_CHANGED" />
             </intent-filter>
         </receiver>
 
-        <receiver android:name="com.jmstudios.redmoon.widget.SwitchAppWidgetProvider">
+        <receiver android:name="com.jmstudios.redmoon.widget.SwitchAppWidgetProvider" android:exported="true">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
             </intent-filter>
@@ -143,7 +147,8 @@
             android:name=".widget.TileReceiver"
             android:icon="@drawable/notification_icon_half_moon"
             android:label="@string/app_name"
-            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>

--- a/app/src/main/java/com/jmstudios/redmoon/Command.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/Command.kt
@@ -20,12 +20,14 @@ private const val DURATION_INSTANT = 0f
 enum class Command(val time: Float) {
     ON(DURATION_LONG) {
         override val turnOn: Boolean = true
+        override val foreground = true
         override fun onAnimationStart(service: FilterService) {
             service.start(true)
         }
     },
     OFF(DURATION_LONG) {
         override val turnOn: Boolean = false
+        override val foreground = false
         override fun onAnimationStart(service: FilterService) {
             service.stopForeground(true)
         }
@@ -35,18 +37,22 @@ enum class Command(val time: Float) {
     },
     PAUSE(DURATION_SHORT) {
         override val turnOn: Boolean = false
+        override val foreground = true
         override fun onAnimationStart(service: FilterService) {
             service.start(false)
         }
     },
     RESUME(DURATION_SHORT) {
         override val turnOn: Boolean = true
+        override val foreground = true
         override fun onAnimationStart(service: FilterService) {
             service.start(true)
         }
     },
     SHOW_PREVIEW(DURATION_INSTANT) {
         override val turnOn: Boolean = true
+        override val foreground = true
+
         override fun onAnimationStart(service: FilterService) {
             if (filterWasOn == null) {
                 filterWasOn = filterIsOn
@@ -57,6 +63,7 @@ enum class Command(val time: Float) {
     HIDE_PREVIEW(DURATION_INSTANT) {
         override val turnOn: Boolean
             get() = filterWasOn == true
+        override val foreground = false
 
         override fun onAnimationEnd(service: FilterService) {
             if (filterWasOn != true) {
@@ -76,7 +83,7 @@ enum class Command(val time: Float) {
         // is started from foreground anyways but there are exceptions: for
         // instance when launched from a quick setting tile.
         // See https://developer.android.com/about/versions/oreo/background
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && this.foreground) {
             appContext.startForegroundService(intent)
         } else {
             appContext.startService(intent)
@@ -84,8 +91,7 @@ enum class Command(val time: Float) {
     }
 
     abstract val turnOn: Boolean
-
-    //override fun toString(): String = javaClass.simpleName
+    abstract val foreground: Boolean
 
     open fun onAnimationStart(service: FilterService) {}
     open fun onAnimationCancel(service: FilterService) {}

--- a/app/src/main/java/com/jmstudios/redmoon/Config.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/Config.kt
@@ -35,8 +35,6 @@ import com.luckycatlabs.sunrisesunset.SunriseSunsetCalculator
 import java.util.Calendar
 import java.util.TimeZone
 
-import me.smichel.android.KPreferences.Preferences
-
 private const val BROADCAST_ACTION = "com.jmstudios.redmoon.RED_MOON_TOGGLED"
 private const val BROADCAST_FIELD  = "jmstudios.bundle.key.FILTER_IS_ON"
 

--- a/app/src/main/java/com/jmstudios/redmoon/KPreferences.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/KPreferences.kt
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2017 Stephen Michel <s@smichel.me>
+ * SPDX-License-Identifier: GPL-3.0+
+ */
+
+package com.jmstudios.redmoon
+
+import android.preference.PreferenceManager.*
+
+import android.content.Context
+import android.content.SharedPreferences
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
+
+private typealias Callback<T> = (T) -> Unit
+
+// These are to cut down on verbosity in Preference subclasses.
+// For clarity, they should not be used elsewhere.
+private typealias B = Boolean
+private typealias L = Long
+private typealias I = Int
+private typealias S = String
+private typealias SS = Set<String>
+
+abstract class Preferences : SharedPreferences.OnSharedPreferenceChangeListener {
+    val prefs: SharedPreferences
+    val context: Context
+
+    constructor(context: Context) {
+        this.context = context
+        prefs = getDefaultSharedPreferences(context)
+    }
+
+    constructor(context: Context, name: String, mode: Int = Context.MODE_PRIVATE) {
+        this.context = context
+        prefs = context.getSharedPreferences(name, mode)
+    }
+
+    private val callbacks = mutableMapOf<String, () -> Unit>()
+
+    var listeningForChanges: Boolean = false
+        set(value) {
+            if (value != field) {
+                field = value
+                if (value) {
+                    prefs.registerOnSharedPreferenceChangeListener(this)
+                } else {
+                    prefs.unregisterOnSharedPreferenceChangeListener(this)
+                }
+            }
+        }
+
+    protected fun registerCallback(key: String, onChange: () -> Unit) {
+        callbacks[key] = onChange
+        listeningForChanges = true
+    }
+
+    protected fun registerCallbacks(keys: List<String>, onChange: () -> Unit) {
+        keys.forEach { key ->
+            registerCallback(key, onChange)
+        }
+    }
+
+    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {
+        callbacks[key]?.invoke()
+    }
+
+    private fun str(resId: Int): String = context.getString(resId)
+
+    inner abstract class Preference<T: Any?>(inline val key: String, inline val default: T) : ReadWriteProperty<Any?, T> {
+        constructor(resId: Int, default: T) : this(str(resId), default)
+        constructor(key: String, default: T, onChange: Callback<T>) : this(key, default) {
+            registerCallback(key){ onChange(prefValue) }
+        }
+        constructor(resId: Int, default: T, onChange: Callback<T>) : this(str(resId), default, onChange)
+
+        protected abstract var prefValue: T
+
+        override fun getValue(thisRef: Any?, property: KProperty<*>) = prefValue
+
+        override fun setValue(thisRef: Any?, property: KProperty<*>, value: T) {
+            prefValue = value
+        }
+    }
+
+    inner class BooleanPreference : Preference<B> {
+        constructor(resId: Int, default: B) : super(resId, default)
+        constructor(key: String, default: B) : super(key, default)
+        constructor(key: String, default: B, onChange: Callback<B>) : super(key, default, onChange)
+        constructor(resId: Int, default: B, onChange: Callback<B>) : super(resId, default, onChange)
+
+        override var prefValue: B
+            get() = prefs.getBoolean(key, default)
+            set(value) = prefs.edit().putBoolean(key, value).apply()
+    }
+
+    inner class IntPreference : Preference<I> {
+        constructor(key: String, default: I) : super(key, default)
+        constructor(resId: I, default: I) : super(resId, default)
+        constructor(key: String, default: I, onChange: Callback<I>) : super(key, default, onChange)
+        constructor(resId: I, default: I, onChange: Callback<I>) : super(resId, default, onChange)
+
+        override var prefValue: I
+            get() = prefs.getInt(key, default)
+            set(value) = prefs.edit().putInt(key, value).apply()
+    }
+
+    inner class LongPreference : Preference<L> {
+        constructor(key: String, default: L) : super(key, default)
+        constructor(resId: Int, default: L) : super(resId, default)
+        constructor(key: String, default: L, onChange: Callback<L>) : super(key, default, onChange)
+        constructor(resId: Int, default: L, onChange: Callback<L>) : super(resId, default, onChange)
+
+        override var prefValue: L
+            get() = prefs.getLong(key, default)
+            set(value) = prefs.edit().putLong(key, value).apply()
+    }
+
+    inner class StringPreference : Preference<S> {
+        constructor(key: String, default: S) : super(key, default)
+        constructor(resId: Int, default: S) : super(resId, default)
+        constructor(key: String, default: S, onChange: Callback<S>) : super(key, default, onChange)
+        constructor(resId: Int, default: S, onChange: Callback<S>) : super(resId, default, onChange)
+
+        override var prefValue: S
+            get() = prefs.getString(key, default)!!
+            set(value) = prefs.edit().putString(key, value).apply()
+    }
+
+    inner class StringSetPreference : Preference<SS> {
+        constructor(key: String, default: SS) : super(key, default)
+        constructor(resId: Int, default: SS) : super(resId, default)
+        constructor(key: String, default: SS, onChange: Callback<SS>) : super(key, default, onChange)
+        constructor(resId: Int, default: SS, onChange: Callback<SS>) : super(resId, default, onChange)
+
+        override var prefValue: SS
+            get() = prefs.getStringSet(key, default)!!
+            set(value) = prefs.edit().putStringSet(key, value).apply()
+    }
+
+    inner class StringOrNullPreference : Preference<S?> {
+        constructor(key: String, default: S? = null) : super(key, default)
+        constructor(resId: Int, default: S? = null) : super(resId, default)
+        constructor(key: String, default: S? = null, onChange: Callback<S?>) : super(key, default, onChange)
+        constructor(resId: Int, default: S? = null, onChange: Callback<S?>) : super(resId, default, onChange)
+
+        override var prefValue: S?
+            get() = prefs.getString(key, default)
+            set(value) = prefs.edit().putString(key, value).apply()
+    }
+
+    inner class StringSetOrNullPreference : Preference<SS?> {
+        constructor(key: String, default: SS? = null) : super(key, default)
+        constructor(resId: Int, default: SS? = null) : super(resId, default)
+        constructor(key: String, default: SS? = null, onChange: Callback<SS?>) : super(key, default, onChange)
+        constructor(resId: Int, default: SS? = null, onChange: Callback<SS?>) : super(resId, default, onChange)
+
+        override var prefValue: SS?
+            get() = prefs.getStringSet(key, default)
+            set(value) = prefs.edit().putStringSet(key, value).apply()
+    }
+}

--- a/app/src/main/java/com/jmstudios/redmoon/Notification.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/Notification.kt
@@ -5,12 +5,14 @@
  */
 package com.jmstudios.redmoon
 
+import android.annotation.SuppressLint
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 
@@ -87,13 +89,26 @@ class Notification(
     }
 
     //region wrappers for readability
+    @SuppressLint("UnspecifiedImmutableFlag")
     private fun servicePI(code: Int, intent: Intent) =
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+            PendingIntent.getService(context, code, intent, PendingIntent.FLAG_UPDATE_CURRENT.or(PendingIntent.FLAG_IMMUTABLE))
+        else
             PendingIntent.getService(context, code, intent, PendingIntent.FLAG_UPDATE_CURRENT)
 
+
+    @SuppressLint("UnspecifiedImmutableFlag")
     private fun activityPI(code: Int, intent: Intent) =
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+            PendingIntent.getActivity(context, code, intent, PendingIntent.FLAG_UPDATE_CURRENT.or(PendingIntent.FLAG_IMMUTABLE))
+        else
             PendingIntent.getActivity(context, code, intent, PendingIntent.FLAG_UPDATE_CURRENT)
 
+    @SuppressLint("UnspecifiedImmutableFlag")
     private fun broadcastPI(code: Int, intent: Intent) =
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+            PendingIntent.getBroadcast(context, code, intent, PendingIntent.FLAG_IMMUTABLE)
+        else
             PendingIntent.getBroadcast(context, code, intent, 0)
 
     private fun NotificationCompat.Builder.addAction(icon: Int, title: Int, intent: PendingIntent) =

--- a/app/src/main/java/com/jmstudios/redmoon/RedMoonApplication.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/RedMoonApplication.kt
@@ -6,19 +6,15 @@
 package com.jmstudios.redmoon
 
 import android.app.Application
-import com.jmstudios.redmoon.helper.Logger
-
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.preference.PreferenceManager
-
+import com.jmstudios.redmoon.helper.Logger
 import com.jmstudios.redmoon.receiver.ScheduleReceiver
-
 import org.json.JSONObject
 
 class RedMoonApplication: Application() {
-
     override fun onCreate() {
         Log.i("onCreate -- Initializing appContext")
         app = this

--- a/app/src/main/java/com/jmstudios/redmoon/Whitelist.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/Whitelist.kt
@@ -4,10 +4,7 @@
  */
 package com.jmstudios.redmoon
 
-import com.jmstudios.redmoon.App
 import com.jmstudios.redmoon.helper.KLogging
-
-import me.smichel.android.KPreferences.Preferences
 
 private const val WHITELIST_PREF: String = "com.jmstudios.redmoon.WHITELIST"
 

--- a/app/src/main/java/com/jmstudios/redmoon/activity/SettingsActivity.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/activity/SettingsActivity.kt
@@ -49,6 +49,7 @@ class SettingsActivity : AppCompatActivity() {
     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>,
                                             grantResults: IntArray) {
         Permission.onRequestResult(requestCode)
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
     }
     companion object : Logger()
 }

--- a/app/src/main/java/com/jmstudios/redmoon/activity/ThemedAppCompatActivity.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/activity/ThemedAppCompatActivity.kt
@@ -53,6 +53,7 @@ abstract class ThemedAppCompatActivity : AppCompatActivity() {
     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>,
                                             grantResults: IntArray) {
         Permission.onRequestResult(requestCode)
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
     }
     companion object : Logger()
 }

--- a/app/src/main/java/com/jmstudios/redmoon/fragment/SettingsFragment.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/fragment/SettingsFragment.kt
@@ -123,7 +123,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
         updateSecureSuspendSummary()
     }
 
-    override fun onDisplayPreferenceDialog(p: Preference?) {
+    override fun onDisplayPreferenceDialog(p: Preference) {
         if (p is TimePreference) {
             TimePreferenceDialogFragmentCompat.newInstance(p.key).let {
                 it.setTargetFragment(this, 0)

--- a/app/src/main/java/com/jmstudios/redmoon/preference/ProfileSelectorPreference.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/preference/ProfileSelectorPreference.kt
@@ -43,7 +43,7 @@ class ProfileSelectorPreference(ctx: Context, attrs: AttributeSet) : Preference(
         layoutResource = R.layout.preference_profile_selector
     }
 
-    override fun onBindViewHolder(holder: PreferenceViewHolder?) {
+    override fun onBindViewHolder(holder: PreferenceViewHolder) {
         super.onBindViewHolder(holder)
         mProfileSpinner = holder?.findViewById(R.id.profile_spinner) as Spinner
         mProfileActionButton = holder?.findViewById(R.id.profile_action_button) as Button

--- a/app/src/main/java/com/jmstudios/redmoon/preference/ProfileSelectorPreference.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/preference/ProfileSelectorPreference.kt
@@ -45,8 +45,8 @@ class ProfileSelectorPreference(ctx: Context, attrs: AttributeSet) : Preference(
 
     override fun onBindViewHolder(holder: PreferenceViewHolder) {
         super.onBindViewHolder(holder)
-        mProfileSpinner = holder?.findViewById(R.id.profile_spinner) as Spinner
-        mProfileActionButton = holder?.findViewById(R.id.profile_action_button) as Button
+        mProfileSpinner = holder.findViewById(R.id.profile_spinner) as Spinner
+        mProfileActionButton = holder.findViewById(R.id.profile_action_button) as Button
 
         initLayout()
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = '1.4.21'
+    ext.kotlin_version = '1.6.10'
     ext.grgit_version = "4.1.0"
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
     dependencies {
         // Platform dependencies
-        classpath 'com.android.tools.build:gradle:4.1.1'
+        classpath 'com.android.tools.build:gradle:7.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // 3rd party
@@ -37,7 +37,7 @@ dependencyUpdates {
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
         maven { url 'https://jitpack.io' }
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Sun Apr 24 18:30:39 EDT 2022
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/timepickerpreference/build.gradle
+++ b/timepickerpreference/build.gradle
@@ -2,11 +2,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 29
+        targetSdkVersion 32
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'
@@ -24,10 +24,10 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'androidx.core:core-ktx:1.3.2'
-    implementation 'androidx.preference:preference:1.1.1'
+    implementation 'androidx.appcompat:appcompat:1.4.1'
+    implementation 'androidx.core:core-ktx:1.7.0'
+    implementation 'androidx.preference:preference:1.2.0'
     testImplementation 'junit:junit:4.13.1'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 }

--- a/timepickerpreference/build.gradle
+++ b/timepickerpreference/build.gradle
@@ -1,16 +1,12 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion 29
-    buildToolsVersion "29.0.2"
 
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 29
-        versionCode 1
-        versionName "0.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'


### PR DESCRIPTION
1) Pulls in KPreferences and removes jcenter
2) Add `FLAG_IMMUTABLE` and `exported` to everything
3) Requests `SCHEDULE_EXACT_ALARM` permissions on Android 12
4) Prevent a crash when scheduling the overlay, caused by some new requirements of foreground services in Android 12

This fixes all of the build errors and crashes related to the new API level - I've tested it on Android 12 and Android 7.