### PR TITLE
Updating FilterService to no longer crash on start on Android O

### DIFF
--- a/app/src/main/java/com/jmstudios/redmoon/service/FilterService.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/service/FilterService.kt
@@ -76,6 +76,7 @@ class FilterService : Service() {
                mFilter.profile = valueAnimator.animatedValue as Profile
             }
         }
+        startForeground(NOTIFICATION_ID, mNotification.build(false))
     }
 
     override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {


### PR DESCRIPTION
Right now if you start red-moon on Android O **without** the draw on top permission, the app will crash after 5 seconds. The cause of this is explained here:

https://stackoverflow.com/questions/44425584/context-startforegroundservice-did-not-then-call-service-startforeground

Essentially:

"The system allows apps to call Context.startForegroundService() even while the app is in the background. However, the app must call that service's startForeground() method within five seconds after the service is created."

Android O behaviour change -- https://developer.android.com/about/versions/oreo/android-8.0-changes.html