### PR TITLE
Add monochrome mode

### DIFF
--- a/app/src/main/java/com/jmstudios/redmoon/Config.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/Config.kt
@@ -84,6 +84,10 @@ object Config : Preferences(appContext) {
         activeProfile.run { if (it != lowerBrightness) activateProfile(copy(lowerBrightness = it)) }
     }
 
+    var monochrome by BooleanPreference(R.string.pref_key_monochrome, false) {
+        activeProfile.run { if (it != monochrome) activateProfile(copy(monochrome = it)) }
+    }
+
     private fun activateProfile(profile: Profile) {
         Log.i("Activating profile: $profile")
         custom = profile

--- a/app/src/main/java/com/jmstudios/redmoon/Profile.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/Profile.kt
@@ -13,6 +13,7 @@ private const val KEY_COLOR     = "color"
 private const val KEY_INTENSITY = "intensity"
 private const val KEY_DIM_LEVEL = "dim"
 private const val KEY_LOWER_BRIGHTNESS = "lower-brightness"
+private const val KEY_MONOCHROME = "monochrome"
 
 /**
  * Color, intensity, and dimLevel range from 0 to 100, inclusive. Regardless of
@@ -28,7 +29,8 @@ data class Profile(
         val color: Int,
         val intensity: Int,
         val dimLevel: Int,
-        val lowerBrightness: Boolean)
+        val lowerBrightness: Boolean,
+        val monochrome: Boolean = false)
     : Event, Comparable<Profile> {
 
     override fun toString() = JSONObject().run {
@@ -36,6 +38,7 @@ data class Profile(
         put(KEY_INTENSITY, intensity)
         put(KEY_DIM_LEVEL, dimLevel )
         put(KEY_LOWER_BRIGHTNESS, lowerBrightness)
+        put(KEY_MONOCHROME, monochrome)
         toString()
     }
 
@@ -48,6 +51,8 @@ data class Profile(
 
     val multFilterColor: Int
         get() {
+            // Don't apply grayscale here - that's done in SurfaceFlinger via color matrix
+            // This just provides the color temperature
             val rgbColor = rgbFromColor(color)
             val intensityColor = intensity / 100.0f
             val dim = dimLevel / 100.0f
@@ -59,6 +64,7 @@ data class Profile(
 
     val filterColor: Int
         get() {
+            // Overlay mode can't do grayscale, so ignore monochrome flag here
             val rgbColor = rgbFromColor(color)
             val intensityColor = Color.argb(floatToColorBits(intensity.toFloat() / 100.0f),
                                             Color.red  (rgbColor),
@@ -111,7 +117,8 @@ data class Profile(
             val intensity = optInt(KEY_INTENSITY)
             val dim       = optInt(KEY_DIM_LEVEL)
             val lowerBrightness = optBoolean(KEY_LOWER_BRIGHTNESS)
-            Profile(color, intensity, dim, lowerBrightness)
+            val monochrome = optBoolean(KEY_MONOCHROME, false)
+            Profile(color, intensity, dim, lowerBrightness, monochrome)
         }
 
         fun getColorTemperature(color: Int): Int = 500 + color * 30

--- a/app/src/main/java/com/jmstudios/redmoon/fragment/FilterFragment.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/fragment/FilterFragment.kt
@@ -60,6 +60,9 @@ class FilterFragment : PreferenceFragmentCompat() {
     private val lowerBrightnessPref: TwoStatePreference
         get() = pref(R.string.pref_key_lower_brightness) as TwoStatePreference
 
+    private val monochromePref: TwoStatePreference?
+        get() = pref(R.string.pref_key_monochrome) as? TwoStatePreference
+
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.filter_preferences, rootKey)
 
@@ -72,6 +75,24 @@ class FilterFragment : PreferenceFragmentCompat() {
                     val checked = newValue as Boolean
                     if (checked) Permission.WriteSettings.request(requireActivity()) else true
                 }
+        
+        // Monochrome only works with root mode
+        updateMonochromeVisibility()
+    }
+    
+    private fun updateMonochromeVisibility() {
+        monochromePref?.let { pref ->
+            pref.isVisible = Config.useRoot
+            pref.summary = if (Config.useRoot) {
+                getString(R.string.pref_summary_monochrome)
+            } else {
+                getString(R.string.pref_summary_monochrome_requires_root)
+            }
+            // If root is disabled and monochrome was on, turn it off
+            if (!Config.useRoot && Config.monochrome) {
+                Config.monochrome = false
+            }
+        }
     }
 
     override fun onStart() {
@@ -94,7 +115,9 @@ class FilterFragment : PreferenceFragmentCompat() {
             intensityPref.setProgress(intensity)
             dimLevelPref.setProgress(dimLevel)
             lowerBrightnessPref.isChecked = lowerBrightness
+            monochromePref?.isChecked = monochrome
         }
+        updateMonochromeVisibility()
     }
     //endregion
 }

--- a/app/src/main/java/com/jmstudios/redmoon/surfaceflinger/SurfaceFlinger.kt
+++ b/app/src/main/java/com/jmstudios/redmoon/surfaceflinger/SurfaceFlinger.kt
@@ -31,18 +31,45 @@ class SurfaceFlinger() : Filter {
     }
 
     private fun update() {
-        val color = activeProfile.multFilterColor
-        val r = Color.red(color) / 255.0f
-        val g = Color.green(color) / 255.0f
-        val b = Color.blue(color) / 255.0f
-        Log.i("Set to $r $g $b")
-        val call = "service call SurfaceFlinger 1015 i32 1 " +
-                "f $r f  0 f  0 f  0 " +
-                "f  0 f $g f  0 f  0 " +
-                "f  0 f  0 f $b f  0 " +
-                "f  0 f  0 f  0 f  1"
-        Log.d(call)
-        Shell.su(call).exec()
+        val profile = activeProfile
+        
+        if (profile.monochrome) {
+            // Apply grayscale matrix first, then color temperature
+            val color = profile.multFilterColor
+            val r = Color.red(color) / 255.0f
+            val g = Color.green(color) / 255.0f
+            val b = Color.blue(color) / 255.0f
+            
+            // Grayscale transformation using luminosity method
+            // Matrix format is column-major: each set of 4 values is a column
+            // For grayscale: R_out = 0.299*R + 0.587*G + 0.114*B, then multiply by color
+            // Column 0 (R input contribution): affects all output channels weighted by color
+            // Column 1 (G input contribution): affects all output channels weighted by color  
+            // Column 2 (B input contribution): affects all output channels weighted by color
+            // Column 3: offset (all zeros)
+            val call = "service call SurfaceFlinger 1015 i32 1 " +
+                    "f ${0.299f * r} f ${0.299f * g} f ${0.299f * b} f 0 " +
+                    "f ${0.587f * r} f ${0.587f * g} f ${0.587f * b} f 0 " +
+                    "f ${0.114f * r} f ${0.114f * g} f ${0.114f * b} f 0 " +
+                    "f 0 f 0 f 0 f 1"
+            Log.i("Set to monochrome with color temp: $r $g $b")
+            Log.d(call)
+            Shell.su(call).exec()
+        } else {
+            // Normal color temperature only
+            val color = profile.multFilterColor
+            val r = Color.red(color) / 255.0f
+            val g = Color.green(color) / 255.0f
+            val b = Color.blue(color) / 255.0f
+            Log.i("Set to $r $g $b")
+            val call = "service call SurfaceFlinger 1015 i32 1 " +
+                    "f $r f  0 f  0 f  0 " +
+                    "f  0 f $g f  0 f  0 " +
+                    "f  0 f  0 f $b f  0 " +
+                    "f  0 f  0 f  0 f  1"
+            Log.d(call)
+            Shell.su(call).exec()
+        }
     }
 
     override fun onCreate() {

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -32,6 +32,7 @@
   <string name="pref_key_intensity" translatable="false">pref_key_shades_intensity_level</string>
   <string name="pref_key_color" translatable="false">pref_key_shades_color_temp</string>
   <string name="pref_key_lower_brightness" translatable="false">pref_key_control_brightness</string>
+  <string name="pref_key_monochrome" translatable="false">pref_key_monochrome</string>
   <string name="pref_key_custom_profile" translatable="false">pref_key_custom_profile</string>
   <string name="pref_key_keep_running_after_reboot" translatable="false">pref_key_keep_running_after_reboot</string>
   <string name="pref_key_always_open_on_startup" translatable="false">pref_key_always_open_on_startup</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,6 +68,9 @@
     <string name="pref_title_intensity">Opacity</string>
     <string name="pref_title_color_temp">Color</string>
     <string name="pref_title_lower_brightness">Lower system brightness</string>
+    <string name="pref_title_monochrome">Monochrome mode</string>
+    <string name="pref_summary_monochrome">Apply black-and-white filter before color temperature. Preserves contrast with extreme color temperatures.</string>
+    <string name="pref_summary_monochrome_requires_root">Requires root mode (enable in Settings)</string>
 
     <string name="pref_title_time_toggle">Timer</string>
     <string name="pref_title_schedule">Run as scheduled</string>

--- a/app/src/main/res/xml/filter_preferences.xml
+++ b/app/src/main/res/xml/filter_preferences.xml
@@ -54,5 +54,13 @@
         android:defaultValue="false"
         app:iconSpaceReserved="false"
         />
+
+    <CheckBoxPreference
+        android:key="@string/pref_key_monochrome"
+        android:title="@string/pref_title_monochrome"
+        android:summary="@string/pref_summary_monochrome"
+        android:defaultValue="false"
+        app:iconSpaceReserved="false"
+        />
   </PreferenceCategory>
 </PreferenceScreen>

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,11 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext.kotlin_version = '1.6.10'
-    ext.grgit_version = "4.1.0"
+    ext.grgit_version = "4.1.1"
     repositories {
         mavenCentral()
         google()
+        gradlePluginPortal()
     }
     dependencies {
         // Platform dependencies


### PR DESCRIPTION
This has been a wishlist feature for me for a while, so I decided to add it 😊

This preserves contrast when using a very low color temperature (close to 500K). It's rooted-only since it can't be replicated without SurfaceFlinger.

Tested on my Pixel 8 Pro running Android 16.

Simulated screenshots (you can see the largest difference in the download links, they're nearly invisible on low brightness without this):
<img width="auto" height="500" alt="enabled" src="https://github.com/user-attachments/assets/bceb4943-9183-4a2d-8082-ea884a66b5d8" />
<img width="auto" height="500" alt="disabled" src="https://github.com/user-attachments/assets/0102f5e4-b3fa-4f73-9009-557831f5eb24" />
